### PR TITLE
test pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Test Site
+on: [pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+      with:
+        ref: trunk
+    - uses: avsm/setup-ocaml@v1.1.0
+      with:
+        ocaml-version: "4.10.0"
+    - run: opam pin add explore.dev -n .
+    - name: External Dependencies
+      run: opam depext -yt explore
+    - name: Dependencies
+      run: opam install -t . --deps-only
+    - name: Build
+      run: opam exec -- dune build 
+    - name: Install
+      run: opam exec -- dune install 
+    - name: Run tests 
+      run: opam exec -- dune runtest
+    - name: Build Site 🔨
+      run: opam exec -- explore build 


### PR DESCRIPTION
Currently things like `dune runtest` and `explore build` only run on `trunk` when trying to build the site and push it to the site branch. Pull requests should ideally do the same minus the pushing of content to the site branch.