### PR TITLE
fix ci checkout and ppx_deriving_yaml dep

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,6 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
-      with:
-        ref: trunk
     - uses: avsm/setup-ocaml@v1.1.0
       with:
         ocaml-version: "4.10.0"

--- a/dune-project
+++ b/dune-project
@@ -44,4 +44,5 @@
   js_of_ocaml-ppx
   js_of_ocaml-compiler
   jekyll-format
-  re))
+  re
+  ppx_deriving_yaml))

--- a/explore.opam
+++ b/explore.opam
@@ -29,6 +29,7 @@ depends: [
   "js_of_ocaml-compiler"
   "jekyll-format"
   "re"
+  "ppx_deriving_yaml"
 ]
 build: [
   ["dune" "subst"] {pinned}


### PR DESCRIPTION
The PR CI was checking out `trunk`... 