### PR TITLE
Replace <hr> by CSS border

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -16,7 +16,7 @@ jobs:
         ocaml-version: "4.10.0"
     - run: opam pin add explore.dev -n .
     - name: External Dependencies
-      run: opam depext -yt explore
+      run: opam depext -y explore
     - name: Dependencies
       run: opam install -t . --deps-only
     - name: Build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
         ocaml-version: "4.10.0"
     - run: opam pin add explore.dev -n .
     - name: External Dependencies
-      run: opam depext -yt explore
+      run: opam depext -y explore
     - name: Dependencies
       run: opam install -t . --deps-only
     - name: Build

--- a/content/index.md
+++ b/content/index.md
@@ -8,8 +8,6 @@ Welcome to Explore OCaml! Explore OCaml is a centralised source for workflows in
 
 # Workflows
 
---------------- 
-
 Below are three lists: archetypical users, meet the tools and community libraries. All workflows have one or more users in mind with most using a tool from the OCaml Platform. The community libraries are popular projects which have become standard for certain workflows. 
 
 To get started with workflows, open the user that best describes you and start exploring! 
@@ -34,8 +32,6 @@ To get started with workflows, open the user that best describes you and start e
 
 # The OCaml Platform 🔨
 
----------------- 
-
 The OCaml Platform is a collection of tools that allow programmers to be productive in the OCaml language. It has been an iterative process of refinement as new tools are added and older tools are updated. Different tools accomplish different workflows and are used at different points of a project's life. You can see how the platform progress in [2017](https://www.youtube.com/watch?v=y-1Zrzdd9KM), [2018](https://www.youtube.com/watch?v=oyeKLAYPmQQ) and [2019](https://speakerdeck.com/avsm/workflows-in-the-ocaml-platform). 
 
 There is no requirement to use all of the tools. You can mix and match different combinations to suit the needs of your project and the workflows you want to accomplish.  
@@ -48,8 +44,6 @@ Community libraries are recommendations for additional tools and libraries to he
 
 <!-- ### Getting started on:
 
----
-
 Brief guides on getting started on the three most common operating systems. There are a few *gotchas* to look out for and alternative ways of doing things with explanations as to what is going on. Start with **common** for a quick review of the problem we're trying to solve. 
 
 [Common](Explore%20OCaml%20294d4a6975e84e509cdc53dc6cb1ba3b/Common%20a4216fb9ab5342c792327110a27c802d.md)
@@ -61,8 +55,6 @@ Brief guides on getting started on the three most common operating systems. Ther
 [Windows](Explore%20OCaml%20294d4a6975e84e509cdc53dc6cb1ba3b/Windows%20e56df5482da84558981dfad34b6e591a.md) -->
 
 ## Notes & Misc.
-
----------------- 
 
 Understanding how these tools came to be requires and understanding of how the OCaml Ecosystem has evolved. This includes tools like `ocamlbuild`, `ocamlfind` and `jbuild`. Many sources of documentation and tutorials still reference some of these out-dated tools and some of the modern platform tools directly use them. 
 

--- a/content/libraries/alcotest/index.md
+++ b/content/libraries/alcotest/index.md
@@ -7,8 +7,6 @@ repo: https://github.com/mirage/alcotest
 
 ## Key Concepts
 
----
-
 The structure of your tests should look something like: 
 
 ```

--- a/content/libraries/bisect/index.md
+++ b/content/libraries/bisect/index.md
@@ -7,8 +7,6 @@ repo: https://github.com/aantron/bisect_ppx
 
 ## Overview
 
----
-
 A tool used to get code coverage information for OCaml programs. It tends to be used in conjunction with `ppx_bisect`.
 
 [Bisect - Introduction](https://bisect.x9c.fr/)

--- a/content/libraries/cstruct/index.md
+++ b/content/libraries/cstruct/index.md
@@ -6,8 +6,6 @@ repo: https://github.com/mirage/ocaml-cstruct
 ---
 ## Overview
 
----
-
 Cstruct is a library for interacting with structs in the C programming language. 
 
 [mirage/ocaml-cstruct](https://github.com/mirage/ocaml-cstruct)

--- a/content/libraries/js_of_ocaml/index.md
+++ b/content/libraries/js_of_ocaml/index.md
@@ -7,8 +7,6 @@ repo: https://github.com/ocsigen/js_of_ocaml
 
 ## Overview
 
----
-
 A compiler that takes OCaml byte-code and compiles it to Javascript - it also offers handy functions for interacting with browser objects like the DOM. 
 
 [ocsigen/js_of_ocaml](https://github.com/ocsigen/js_of_ocaml)

--- a/content/libraries/logs/index.md
+++ b/content/libraries/logs/index.md
@@ -7,8 +7,6 @@ repo: https://github.com/dbuenzli/logs
 
 ## Overview
 
----
-
 This is a very powerful, yet difficult to get started with library for doing logging in OCaml. The key idea is that logging should:
 
 1. Have a severity of reporting level (`Debugger`, `Error` ...)

--- a/content/libraries/odoc/index.md
+++ b/content/libraries/odoc/index.md
@@ -7,8 +7,6 @@ repo: https://github.com/ocaml/odoc
 
 ## Overview
 
----
-
 Odoc is a documentation compiler for OCaml - it takes your project and extracts all of the `(** *)` documentation comments and builds a small website for navigating your API. 
 
 [ocaml/odoc](https://github.com/ocaml/odoc)

--- a/content/libraries/owl/index.md
+++ b/content/libraries/owl/index.md
@@ -7,8 +7,6 @@ repo: https://github.com/owlbarn/owl
 
 ## Overview
 
----
-
 OWL is a scientific computing library for OCaml - the Real World OCaml styled book can be found here: 
 
 [OCaml Scientific Computing](https://ocaml.xyz/book/)

--- a/content/libraries/ppxlib/index.md
+++ b/content/libraries/ppxlib/index.md
@@ -7,8 +7,6 @@ repo: https://github.com/ocaml-ppx/ppxlib
 
 ## Overview
 
----
-
 The recommended tool for writing your PPX libraries 
 
 [ocaml-ppx/ppxlib](https://github.com/ocaml-ppx/ppxlib)

--- a/content/pages/ocaml-platform/index.md
+++ b/content/pages/ocaml-platform/index.md
@@ -6,8 +6,6 @@ date: 2020-07-27 09:35:49
 
 [https://www.youtube.com/watch?v=oyeKLAYPmQQ](https://www.youtube.com/watch?v=oyeKLAYPmQQ)
 
----
-
 ## Summary in a Q&A Format
 
 **User Concerns:**
@@ -78,8 +76,6 @@ date: 2020-07-27 09:35:49
     - Long term support for *important* versions of the OCaml compiler (for example those used by Bucklescript)
     - Precompiled tools to make getting started as quick as possible (similar to `go get`).
     - The *monorepo* approach provides better visibility into how changes in a single platform tools impacts others.
-
----
 
 **Technical Details** 
 

--- a/content/pages/opam-client/index.md
+++ b/content/pages/opam-client/index.md
@@ -6,8 +6,6 @@ date: 2020-08-03 13:20:39
 
 ## Overview
 
----
-
 opam is an OCaml Package Manager. It handles the sharing of libraries and code, dependency management and installation. In addition to this it also handles compiler installation. Opam handles what the following do for other languages: 
 
 - Rust: `rustup` & `cargo`
@@ -19,8 +17,6 @@ opam is an OCaml Package Manager. It handles the sharing of libraries and code, 
 A simplfied diagram of some of the key features in opam
 
 ## Key Concepts
-
----
 
 ### Switches
 
@@ -69,4 +65,4 @@ Show allows you to see the metadata associated with a library. You can even prin
 
 Plugins in opam are ways to extend opam's functionality in a more accessible way (anyone can write a plugin!). One of the most used is [depext](https://github.com/ocaml-opam/opam-depext) - you can tell it is a plugin from it's opam file which has `tags: "flags:plugin"`. Depext tries to install external dependencies for you. Other plugins include `opam-user-setup` which can be used to setup common tooling for supported editors like *emacs* or *vim.*
 
-Another plugin is [opam-tools](https://github.com/avsm/opam-tools) which initialises a local development environment (i.e. using a local switch). The goal is that you could clone a repository and run `opam tools` which should do a lot of the manual setup to start developing for you. 
+Another plugin is [opam-tools](https://github.com/avsm/opam-tools) which initialises a local development environment (i.e. using a local switch). The goal is that you could clone a repository and run `opam tools` which should do a lot of the manual setup to start developing for you.

--- a/content/platform/bun/index.md
+++ b/content/platform/bun/index.md
@@ -8,8 +8,6 @@ license: MIT
 
 ## Overview
 
----
-
 [Bun](https://github.com/yomimono/ocaml-bun) is a CLI tool for integrating fuzzer-based testing into a continuous integration pipeline. Some of the main problems it solves are: 
 
 1. Fuzz tests need time to properly work and most CI tools can kill long running processes. 
@@ -18,8 +16,6 @@ license: MIT
 
 ### Key Concepts
 
----
-
 Bun is all about fuzz testing, so make sure you're [up to speed with it](/workflows/fuzz-testing-your-project). 
 
 As a very brief synopsis, fuzz testing is about instrumenting your code to allow a fuzzer to analyse input and output from functions to cleverly detect edge cases that are more likely to break your code. This is especially useful when implementing complex functions that could take many different inputs like parsers or implementations of protocols. 
@@ -27,6 +23,4 @@ As a very brief synopsis, fuzz testing is about instrumenting your code to allow
 
 ### In the Wild
 
----
-
-[Cstruct](https://github.com/mirage/ocaml-cstruct) is a library for mapping OCaml values to C-like structs. It uses fuzz-based testing along with the [Drone](https://drone.io/) CI tool. The [fuzz](https://github.com/mirage/ocaml-cstruct/tree/master/fuzz) directory contains the relevant code.  
+[Cstruct](https://github.com/mirage/ocaml-cstruct) is a library for mapping OCaml values to C-like structs. It uses fuzz-based testing along with the [Drone](https://drone.io/) CI tool. The [fuzz](https://github.com/mirage/ocaml-cstruct/tree/master/fuzz) directory contains the relevant code.

--- a/content/platform/dune-release/index.md
+++ b/content/platform/dune-release/index.md
@@ -8,12 +8,8 @@ license: None
 
 ## Overview
 
----
-
 [Dune-release](https://github.com/ocamllabs/dune-release) is a command line tool that can be used to *"streamline the process of releasing packages to opam*". It helps automate some of the more laborious or difficult tasks of releasing a package such as generating the distribution archive, using git tags to mark version releases, pushing new documentation to your Github repository, making pull requests to the [opam repository](https://github.com/ocaml/opam-repository) etc. 
 
 ## Key Concepts
-
----
 
 For its core functionality, *dune-release* has a few basic commands that will do most of the release work for you. These are outlined in the *related workflows* section above.

--- a/content/platform/dune/index.md
+++ b/content/platform/dune/index.md
@@ -7,15 +7,11 @@ license: MIT
 ---
 ## Overview
 
----
-
 Dune is a build tool that has been widely adopted in the OCaml world - it plays nicely with lots of other tools like opam and mdx. The documentation is very thorough - but do checkout the *key concepts* to get a high-level overview of how dune works and how to get started building your OCaml project. 
 
 [Welcome to dune's documentation! - dune documentation](https://dune.readthedocs.io/en/stable/)
 
 ## Key Concepts
-
----
 
 ### Compositional Builds
 
@@ -67,8 +63,6 @@ The following file structure is taken from `ocaml-yaml` and has been trimmed to 
 ```
 
 ## In the Wild
-
----
 
 Dune is used in a lot of OCaml projects thanks to its flexibility, integration with opam and lightweightness. Below are just a few projects using dune: 
 

--- a/content/platform/mdx/index.md
+++ b/content/platform/mdx/index.md
@@ -8,13 +8,9 @@ license: ISC
 
 ## Overview
 
----
-
 [Mdx](https://github.com/realworldocaml/mdx) is a tool for executing code blocks inside of markdown. It can be used to improve documentation workflows and write tests. Documentation struggles from becoming out-dated fairly quickly or just being incorrect given it is usually typed by a programmer into something like markdown.  
 
 ## Key Concepts
-
----
 
 ### Dune Integration
 
@@ -25,7 +21,5 @@ license: ISC
 - `preludes` - files to run before anything else, useful for automatically opening packages like `Core`
 
 ## In the Wild
-
----
 
 The excellent book for learning OCaml, [Real World OCaml,](https://github.com/realworldocaml/book) uses mdx extensively to automate their book and ensure the code snippets included within it are correct. Code is written in an *examples* directory and mdx keeps the examples and embedded code blocks in the content of the book synchronised.

--- a/content/platform/merlin/index.md
+++ b/content/platform/merlin/index.md
@@ -8,13 +8,9 @@ license: MIT
 
 ## Overview
 
----
-
 [Merlin](https://github.com/ocaml/merlin) is a tool for providing IDE features for OCaml with support for Vim and Emacs. If you want to set up either of these editors for a modern OCaml editting experience be sure to check out the related workflows section. 
 
 ## Key Concepts
-
----
 
 ### Installation 
 

--- a/content/platform/ocamlformat/index.md
+++ b/content/platform/ocamlformat/index.md
@@ -8,13 +8,9 @@ license: MIT
 
 ## Overview
 
----
-
 [OCamlFormat](https://github.com/ocaml-ppx/ocamlformat) is a tool for applying formatting decisions to an OCaml project - it supports 
 
 ## Key Concepts
-
----
 
 ### Versioning
 
@@ -31,7 +27,5 @@ The full, tuneable options list can be seen with `ocamlformat --help` but to giv
 - *space-around-records=true*: this is set by default (along with arrays and lists) which formats these values as `{ age = 3 }` rather than `{age=3}` which again helps with legibility.
 
 ## In the Wild
-
----
 
 Lots of large code bases now uses OCamlFormat to make styling one less thing to worry about. Facebook's [Infer](https://github.com/facebook/infer/blob/master/infer/src/.ocamlformat) uses it as well as [Mirage](https://github.com/mirage/mirage/blob/master/.ocamlformat).

--- a/content/platform/ocp-indent/index.md
+++ b/content/platform/ocp-indent/index.md
@@ -8,13 +8,9 @@ repo: https://github.com/OCamlPro/ocp-indent
 
 ## Overview
 
----
-
 [Ocp-indent](https://github.com/OCamlPro/ocp-indent) is an indentation tool for OCaml. Unlike Python, the level of indentation will not change the semantics of your OCaml program, but it will make it more or less readable.  For complete styling you should use OCamlFormat and for indentation, Ocp-indent. 
 
 ## Key Concepts
-
----
 
 ### Tuneable Parameters
 
@@ -31,7 +27,5 @@ let foo () =
 Ocp-indent comes with useful extensions for the OCaml language - in particular you can use the *mll* extension for indenting the lexing file format.
 
 ## In the Wild
-
----
 
 Ocp-indent is used in the [OCaml compiler repository](https://github.com/ocaml/ocaml/blob/trunk/.ocp-indent).

--- a/content/platform/utop/index.md
+++ b/content/platform/utop/index.md
@@ -8,13 +8,9 @@ repo: https://github.com/ocaml-community/utop
 
 ## Overview
 
----
-
 [Utop](https://github.com/ocaml-community/utop) is the *universal top-level* for OCaml. It is essentially a *read-evaluate-print* loop which makes it great for prototyping functions, learning OCaml and checking type signatures. It can be installed using opam with `opam install utop`. 
 
 ## Key Concepts
-
----
 
 Utop is much more than just a learning tool - it can help any OCaml programmer discover type signatures and prototype new ideas quickly without having to build a full program. Some of the most useful directives are: 
 

--- a/content/platform/visual-studio-code/index.md
+++ b/content/platform/visual-studio-code/index.md
@@ -8,8 +8,6 @@ repo: https://github.com/ocamllabs/vscode-ocaml-platform
 
 ## Overview
 
----
-
 The OCaml Platform VS Code plugin in combination with the `ocaml-lsp-server` package enhance the VS Code editing experience by offering real-time annotations to code for things like type checking, pattern-matching and code completion. 
 
 [ocamllabs/vscode-ocaml-platform](https://github.com/ocamllabs/vscode-ocaml-platform)

--- a/content/workflows/adding-unit-tests-to-your-project/index.md
+++ b/content/workflows/adding-unit-tests-to-your-project/index.md
@@ -14,15 +14,11 @@ libraries:
 ---
 ## Overview
 
----
-
 Testing is critical to ensuring the longevity of your project. When writing code it is very likely some new implementation will break something you wrote before. Testing provides visibility into this. 
 
 There are lots of ways you can go about testing and a large part of this is dependent on the type of project you are working on - is it a command line tool, a library, a web-application etc. This workflow focuses mainly on writing unit tests for your OCaml code and so will likely be applicable to most applications. 
 
 ## Recommended Workflow
-
----
 
 ### Testing a library with Alcotest
 
@@ -173,8 +169,6 @@ $ main -1
 
 ## Alternatives
 
----
-
 ### QCheck
 
 [QCheck](https://github.com/c-cube/qcheck) is based on Haskell's [QuickCheck](https://hackage.haskell.org/package/QuickCheck) library for property-based testing. It also offers a sub-library that can integrate directly with Alcotest.  
@@ -184,7 +178,5 @@ $ main -1
 These tests tend to be written inline with your source OCaml code using `ppx_inline_test`. To get expect tests you can use `ppx_expect` to write assertions about parts of your program. The [documentation](https://dune.readthedocs.io/en/stable/tests.html) covers all of this in much more detail. 
 
 ## Real World Examples
-
----
 
 [Yojson](https://github.com/ocaml-community/yojson/tree/master/test) is good example of using Alcotest to unit test the different aspects of the library. [Dune-release](https://github.com/ocamllabs/dune-release/tree/master/tests/bin), part of the OCaml Platform, uses Mdx to ensure the CLI tool is properly tested.

--- a/content/workflows/checking-code-coverage/index.md
+++ b/content/workflows/checking-code-coverage/index.md
@@ -16,13 +16,9 @@ libraries:
 
 ## Overview
 
----
-
 Code coverage can be a good indicator into how well your code does what it is supposed to do. Of course, the goal is not to blindly chase 100% coverage, but to use the output to help you write correct and maintainable code. 
 
 ## Recommended Workflow
-
----
 
 Setting up code coverage requires changes to your `dune` file for the libraries you want to cover. You will also need to update your opam file to depend on `ppx_bisect`. The opam file will add `bisec_ppx` as a dependency: 
 
@@ -56,7 +52,5 @@ bisect-ppx-report html
 ```
 
 ## Real World Examples
-
----
 
 [arenadotio/ocaml-mssql](https://github.com/arenadotio/ocaml-mssql)

--- a/content/workflows/compiling-for-y-on-x/index.md
+++ b/content/workflows/compiling-for-y-on-x/index.md
@@ -12,15 +12,11 @@ tools:
 
 ## Overview
 
----
-
 Cross-compiling in OCaml is still an experimental feature, but there are plans to make it a fully supported one in the future. 
 
 Cross-compiling allows a programmer on, for example, an *x86* machine to compile OCaml code to run on a *RISC-V* device. Usually the target architecture is the same as the architecture our machine is running on. This is particularly useful for embedded devices running architectures like *ARM-32, ESP-32 or RISC-V*. 
 
 ## Recommended Workflow
-
----
 
 ### Building for Different Architectures
 
@@ -36,8 +32,6 @@ Luckily, that is fairly easy. Below, in real world examples, there are some repo
 Quite often you will be interested in knowing if your library works on different operating systems like Linux, MacOS and Windows. The easiest way to do this is to setup a Github Actions workflow which tests on all three of theses OSes. For more details on how to do this, check out the [continuous integration workflow](/workflows/setting-up-continuous-integration).
 
 ## Real World Examples
-
----
 
 ### Example opam repositories
 

--- a/content/workflows/configuring-ocaml-tools-for-your-editor/index.md
+++ b/content/workflows/configuring-ocaml-tools-for-your-editor/index.md
@@ -23,13 +23,9 @@ resources:
 
 ## Overview
 
----
-
 Having a helpful development environment can boost productivity and help catch errors early. OCaml has a powerful type system which reduces runtime errors, with a good editor setup you'll be able to catch them before you run `dune build`.
 
 ## Recommended Workflow
-
----
 
 ### Visual Studio Code 
 
@@ -61,8 +57,6 @@ There are a few quality of life improvements you can make when working with OCam
 Now whenever you save a file it will apply the formatting changes for you. 
 
 ## Alternatives
-
----
 
 ### Other VS Code Plugins
 

--- a/content/workflows/documenting-your-project/index.md
+++ b/content/workflows/documenting-your-project/index.md
@@ -17,8 +17,6 @@ libraries:
 
 ## Overview
 
----
-
 Documentation is vital for your library to be used by other people, it also helps others to contribute and even reminds you of your design decisions. 
 
 The goal of the  workflow is to make your documentation:
@@ -28,8 +26,6 @@ The goal of the  workflow is to make your documentation:
 - Correct - your documentation will likely contain code examples and workflows, these should be checked for correctness in an automated way.
 
 ## Recommended Workflow
-
----
 
 ### Writing Documentation using Odoc 
 
@@ -79,7 +75,5 @@ $ dune-release publish doc # build and push docs to gh-pages
 ```
 
 ## Real World Examples
-
----
 
 Many frequently used OCaml libraries take advantage of this easy workflow for publishing documentation as part of the release process for a new version of a package. Good examples are [Irmin](https://mirage.github.io/irmin/) and [Cohttp](https://mirage.github.io/ocaml-cohttp/).

--- a/content/workflows/finding-answers-to-your-questions/index.md
+++ b/content/workflows/finding-answers-to-your-questions/index.md
@@ -15,13 +15,9 @@ users:
 
 ## Overview
 
----
-
 Compared to other more popular languages, OCaml has a lot less instructional tutorials and helpful stack-overflow questions. For any user, this can be incredibly frustrating. Finding answers can be different depending on what user you are, but some places offer a good starting point for nearly everyone.
 
 ## Recommended Workflow
-
----
 
 ### Discuss OCaml
 
@@ -34,8 +30,6 @@ OCaml has a very active and supportive discussion forum which is most people's f
 Another great place to look for answers for a specific library or executable is in the Github issues of that library. Often bugs are reported which might just be because of a confusing API and the maintainers of the code clear it up and close the issue - use this to your advantage and learn from them. This is also a good sanity-check before you disappear down the rabbit hole to debug something!
 
 ## Alternatives
-
----
 
 ### Caml Mailing List & Discord
 

--- a/content/workflows/fixing-bugs-in-3rd-party-packages/index.md
+++ b/content/workflows/fixing-bugs-in-3rd-party-packages/index.md
@@ -16,8 +16,6 @@ resources:
 
 ## Overview
 
----
-
 Working with third-party packages means coming across areas for improvement or those that need fixing. Knowing how common codebases are structured and an appreciation for the tools allows you to more easily:
 
 - Fix the bug if you know how.
@@ -35,8 +33,6 @@ There are multiple aspects to unpack in this workflow including:
 Quite a lot of this workflow is made simpler by using the [opam client](/pages/opam-client). 
 
 ## Recommended Workflow
-
----
 
 ### Getting the Source Code
 
@@ -75,4 +71,4 @@ Keeping track of what packages you have pinned and which ones you haven't can be
 
 ### Subsequent Changes & Upgrading
 
-Pinning a package tells opam where the source code is coming from but as you add new bits of code, opam doesn't see these. In order to add those you will have to run `opam upgrade` to get the latest changes of pinned packages. 
+Pinning a package tells opam where the source code is coming from but as you add new bits of code, opam doesn't see these. In order to add those you will have to run `opam upgrade` to get the latest changes of pinned packages.

--- a/content/workflows/fuzz-testing-your-project/index.md
+++ b/content/workflows/fuzz-testing-your-project/index.md
@@ -13,13 +13,9 @@ tools:
 
 ## Overview
 
----
-
 Fuzz testing (or fuzzing) is a way to find test cases that break your code programmatically using instrumented binaries. This can extremely useful for complex parsers or protocols which are expected to cope with a large variety of inputs.
 
 ## Recommended Workflow
-
----
 
 To get started with fuzzing your project you will need to do the following: 
 
@@ -32,5 +28,3 @@ This Github repository and the accompanying article found in the resource tag ar
 [NathanReb/ocaml-afl-examples](https://github.com/NathanReb/ocaml-afl-examples)
 
 ## Real World Examples
-
----

--- a/content/workflows/getting-started/index.md
+++ b/content/workflows/getting-started/index.md
@@ -13,15 +13,11 @@ tools:
 
 ## Overview
 
----
-
 The "Getting Started" workflow is meant for somebody who just wants to try the OCaml language. The full extent to what they want to achieve is likely a few `.ml` files inside a directory using only tools from the standard library. 
 
 The barrier to entry should be low, it should be intuitive to setup and get started quickly. This is deal for OCaml workshops or education settings (in the first instance) before introducing more compilicated tooling to support larger more ambitious projects in the language. 
 
 ## Recommended Workflow
-
----
 
 For beginners how just want to try the language, the fastest and simplest solution is to use one of the tools that runs in the browser. Currently there are two options: 
 
@@ -38,8 +34,6 @@ Very similar to Try OCaml with a toplevel and additionally, a series of OCaml ex
 [ocaml-sf/learn-ocaml](https://github.com/ocaml-sf/learn-ocaml)
 
 ## Alternatives
-
----
 
 [Ocsigen](https://ocsigen.org/home/intro.html), the creators and maintainers of `js_of_ocaml`, have an interactive toplevel with some nice examples. The related workflows link to more complex examples like interactiving with the DOM using OCaml. 
 

--- a/content/workflows/incorporating-non-ocaml-code-into-your-project/index.md
+++ b/content/workflows/incorporating-non-ocaml-code-into-your-project/index.md
@@ -22,13 +22,9 @@ resources:
 
 ## Overview
 
----
-
 Sometimes OCaml just can't do what lower level languages can do or you want to use pre-existing code written in C or Rust from OCaml. 
 
 ## Recommended Workflow
-
----
 
 ### OCaml Internals 
 
@@ -115,8 +111,6 @@ Sometimes you might want to do the inverse and access parts on an [OCaml program
 In order for C to find OCaml functions you need to register them as callbacks using `Callback.register`. This [small example](https://github.com/patricoferris/ocaml-c-example) calls a fibonacci function written in OCaml from C. Note the additional C compiler parameters in the Makefile for linking in the standard library and only producing an object OCaml file. 
 
 ## Real World Examples
-
----
 
 [Digestif](https://github.com/mirage/digestif/tree/master/src-c/native) implements many common hashing algorithms both in C and OCaml.
 

--- a/content/workflows/initialising-a-new-library/index.md
+++ b/content/workflows/initialising-a-new-library/index.md
@@ -12,15 +12,11 @@ tools:
 
 ## Overview
 
----
-
 Getting started with a project should be simple - ideally a single command would initialise some kind of wizard to guide you through setting a project up. Much like the `npm init` command which takes answers to populate the `package.json` file. 
 
 This is important because it is very easy to make mistakes in setting up a repository for a new project and the ideal workflow for a library author would to start writing code almost immediately.
 
 ## Recommended Workflow
-
----
 
 ### Opam and Dune
 
@@ -48,8 +44,6 @@ Using the `dune-project` file to [generate your opam file](https://dune.readthed
 Note that sometimes you need an escape-hatch as the specification in `dune-project` for opam files is not as flexible as an opam file - for this you should use the [templates](https://dune.readthedocs.io/en/stable/opam.html#opam-template) as an escape-hatch. 
 
 ## Real World Examples
-
----
 
 Many of the community libraries use dune and opam to build their projects - [cstruct](https://github.com/mirage/ocaml-cstruct) and [alcotest](https://github.com/mirage/alcotest) for example. 
 

--- a/content/workflows/keeping-your-code-clean/index.md
+++ b/content/workflows/keeping-your-code-clean/index.md
@@ -14,16 +14,12 @@ tools:
 
 ## Overview
 
----
-
 Having a unified approach to formatting is important for multiple reasons: 
 
 - Good for beginners: using tooling to help properly format, code-complete, syntax highlighting etc. removes this burden (somewhat) for new people lowering the barrier of entry for contributions.
 - Easier to read: the code tends to be easier to read (or will be once the standard formatting is learnt) which helps onboard new people to a codebase and also discover bugs.
 
 ## Recommended Workflow
-
----
 
 ### OCamlformat
 
@@ -51,8 +47,6 @@ set rtp^="$(opam config var ocp-indent:share)/vim"
 ```
 
 ## Real World Examples
-
----
 
 [mirage/alcotest](https://github.com/mirage/alcotest/blob/master/.ocamlformat)
 

--- a/content/workflows/meta-programming-with-ppx/index.md
+++ b/content/workflows/meta-programming-with-ppx/index.md
@@ -19,8 +19,6 @@ resources:
 
 ## Overview
 
----
-
 Meta-programming is programming for programming. You can think of it as a program which works with another program as data. Ppx is the OCaml syntax extension allowing programmers to meta-program directly on the abstract syntax tree (AST) of OCaml code. This means simple tasks like writing comparison functions or hashing functions can be automated through clever inference on types. 
 
 ### The Abstract Syntax Tree 
@@ -86,8 +84,6 @@ If the tree structure does not reveal itself from the code, this greatly simplif
 Manipulating the tree structure is much simpler than working with text. A ppx works on these structures allowing you to access the information and perform transformations from one tree to another. 
 
 ## Recommended Workflow
-
---- 
 
 ### Using PPX libraries
 
@@ -162,8 +158,6 @@ To write your own ppx library you are strongly encourage to use `ppxlib` (linked
 The best way to learn is by example. Let's continue with some of Jane Street's ppxes and look at how `ppx_compare` works. 
 
 ## Real World Examples
-
----
 
 [ocaml-ppx/ppx_deriving_yojson](https://github.com/ocaml-ppx/ppx_deriving_yojson)
 

--- a/content/workflows/navigating-ocaml-projects/index.md
+++ b/content/workflows/navigating-ocaml-projects/index.md
@@ -13,12 +13,10 @@ resources:
     description: Craig Ferguson explains a different way of laying out OCaml compilation units to reduce duplication of type information and the tradeoffs associated with it. This is a technique commonly used by Jane Street in their OSS.
 ---
 ## Overview 
-----
 
 Looking at the root of an OCaml project can be intimidating - there can be many files and many directories. There are, however, some common standards and best practices that many OCaml libraries use. This workflow aims to help you navigate most OCaml projects.
 
 ## Structure 
-----
 
 ### Files in the top-level directory
 
@@ -91,6 +89,3 @@ There are many different ways to structure an OCaml project, particularly when y
 
 - `fuzz` and `bench` directories - these hold [fuzz tests](/workflows/fuzz-testing-your-project) and [benchmarks](profiling-your-project) respectively. 
 - `doc` directory or `gh-pages` branch - either one of these may contain the result of producing documentation with the [odoc](/libraries/odoc) tool. The [documentation workflow](/workflows/documenting-your-project) explains how this works. 
-
- 
- 

--- a/content/workflows/profiling-your-project/index.md
+++ b/content/workflows/profiling-your-project/index.md
@@ -26,8 +26,6 @@ resources:
 
 ## Overview
 
----
-
 For profiling programs there tend to be two main properties that most developers care about performance and memory usage.  
 
 OCaml is a garbage-collected programming language, but there are ways to alleviate the the strain on the GC. There is also good support for profiling the performance of your program to find the sections that are consuming the most execution time. 
@@ -61,7 +59,6 @@ Here, we compiled an alias (`compare`) to the less than or equal operation outpu
 Hopefully these examples provide insight into how an OCaml program runs. This is very important for understanding what the tools we'll cover later, like perf, tell us. For more information, the [OCaml Manual](https://caml.inria.fr/pub/docs/manual-ocaml/) is probably the best place to start.
 
 ## Performance 
---- 
 
 Performance is a complex beast with many differing objectives when it comes to analysing code for "performance". Not only that but lots of seemingly unrelated factors impact how code performs: garbage collection, the OS scheduler and CPU oddities to name a few. Sometimes the variations caused by these factors are neglible -- macro-benchmarking -- and sometimes they're not and clever analysis is needed to smooth them out, micro-benchmarking. 
 
@@ -337,8 +334,6 @@ let alloc n =
 Running `alloc 10` and collecting GC statistics with `Gc.print_stat ()` shows that there were no minor or major heap collections. Changing that to `alloc 1000` gives `23` minor heap and `5` major heap collections. There is a brilliant chapter in [Real World OCaml](https://dev.realworldocaml.org/garbage-collector.html) that goes into garbage collection in much more detail.
 
 ## Alternatives
-
----
 
 ### Performance with `gprof`
 

--- a/content/workflows/publishing-a-new-package-on-opam/index.md
+++ b/content/workflows/publishing-a-new-package-on-opam/index.md
@@ -14,16 +14,8 @@ tools:
 
 ## Overview
 
----
-
 ## Recommended Workflow
-
----
 
 ## Alternatives
 
----
-
 ## Real World Examples
-
----

--- a/content/workflows/releasing-new-versions-of-your-package/index.md
+++ b/content/workflows/releasing-new-versions-of-your-package/index.md
@@ -13,16 +13,8 @@ tools:
 
 ## Overview
 
----
-
 ## Recommended Workflow
-
----
 
 ## Alternatives
 
----
-
 ## Real World Examples
-
----

--- a/content/workflows/running-ocaml-in-your-browser/index.md
+++ b/content/workflows/running-ocaml-in-your-browser/index.md
@@ -14,13 +14,9 @@ libraries:
 
 ## Overview
 
----
-
 OCaml byte-code can be compiled to Javascript to run in your browser using the `js_of_ocaml` compiler linked in the libraries tag. This allows you to write statically type-checked OCaml code to run in a website rather than dynamically typed Javascript - this gives you more guarantees over what errors you will get at runtime. 
 
 ## Recommended Workflow
-
----
 
 ### Js_of_ocaml
 
@@ -72,8 +68,6 @@ let () =
 
 ## Alternatives
 
----
-
 ### Bucklescript
 
 An alternative is to use Bucklescript to compile your OCaml code to Javascript. At this point you will have to leave dune behind you and venture into the world of Bucklescript and `npm` - [this post on discuss OCaml](https://discuss.ocaml.org/t/js-of-ocaml-vs-bucklescript/2293/7) might be worthwhile reading to find out which is best for you. 
@@ -81,7 +75,5 @@ An alternative is to use Bucklescript to compile your OCaml code to Javascript. 
 [BuckleScript · A faster, simpler and more robust take on JavaScript.](https://bucklescript.github.io/)
 
 ## Real World Examples
-
----
 
 Jane Street have written a library for building dynamic webapps that uses `js_of_ocaml` extensively: [incr_dom](https://github.com/janestreet/incr_dom). There are some great [examples](https://github.com/janestreet/incr_dom/tree/master/example) to get started with.

--- a/content/workflows/setting-up-continuous-integration/index.md
+++ b/content/workflows/setting-up-continuous-integration/index.md
@@ -14,8 +14,6 @@ tools:
 
 ## Overview
 
----
-
 Continuous integration (CI) has become a basic necessity for managing projects, especially when there are multiple contributors. The idea is that for code to make it into production (or to get a "seal of approval" to move to the main branch) - code should pass a series of quality tests. 
 
 These tests may include: 
@@ -27,8 +25,6 @@ These tests may include:
 The point of CI is to automate most of this away. Wherever your project lives it should constantly be checking that new code meets the quality tests before allowing that code to make into "production". 
 
 ## Recommended Workflow
-
----
 
 Github offers a feature called Github Actions. It works on the principle of *workflows -* different things you might want to do on different "actions" within your Github repository. This can include releasing code, testing code etc. Here we're focusing on testing. 
 
@@ -68,8 +64,6 @@ jobs:
 
 ## Alternatives
 
----
-
 TravisCI is a continuous integration tool that is very flexible and also robust. There are two main ways you can use TravisCI.
 
 `ocaml-ci-scripts` is a collection of useful scripts for building a complex CI testing platform. One of the main goals of CI is to make sure your code runs well *everywhere.* This implies forming a matrix of operating systems and OCaml compiler versions to make sure your code runs properly. 
@@ -79,7 +73,5 @@ There are quite few scripts such as `.travis.opam.sh` ,  `.travis.docker.sh` and
 Each is built around environment variables in order to execute different jobs with say different linux distributions, ocaml versions etc. 
 
 ## Real World Examples
-
----
 
 [avsm/ocaml-yaml](https://github.com/avsm/ocaml-yaml/blob/master/.github/workflows/test.yml)

--- a/content/workflows/teaching-and-data-science/index.md
+++ b/content/workflows/teaching-and-data-science/index.md
@@ -13,15 +13,11 @@ libraries:
 
 ## Overview
 
----
-
 Jupyter notebooks combine an interactive read-evaluate-print-loop (REPL) with markdown text (with support for LATEX) to offer a unique solution for people wanting to teach, explore OCaml or perform more data-centric operations (ML models etc.) 
 
 From a learning point-of-view, students are more concerned with *syntax* and *concepts* rather than tooling (in the beginning). Much like `utop` the REPL format is great for learning, but with **jupyter** you can also write notes, explain algorithms etc. 
 
 ## Recommended Workflow
-
----
 
 ### Locally Running an OCaml Jupyter Notebook
 
@@ -45,8 +41,6 @@ For teachers or presenters you can use the [RISE](https://rise.readthedocs.io/en
 
 ## Alternatives
 
----
-
 ### Using Docker to run a Notebook
 
 Using the link below, a jupyter notebook can be created inside a docker container and connected to a port so users can begin coding fairly quickly. This involves a second level of indirection in installing docker. 
@@ -61,7 +55,5 @@ docker run -it -p 8888:8888 akabe/ocaml-jupyter-datascience -v $PWD:/notebooks a
 [akabe/docker-ocaml-jupyter-datascience](https://github.com/akabe/docker-ocaml-jupyter-datascience)
 
 ## Real World Examples
-
----
 
 [](https://kcsrk.info/ocaml/prolog/jupyter/notebooks/2020/01/19/OCaml-Prolog-Jupyter/)

--- a/content/workflows/using-tools-written-in-ocaml/index.md
+++ b/content/workflows/using-tools-written-in-ocaml/index.md
@@ -11,13 +11,9 @@ tools:
 ---
 ## Overview
 
----
-
 OCaml is a very productive language for building tools for people who have non-intention (at least at the beginning) of writing any OCaml code.
 
 ## Real World Examples
-
----
 
 [facebook/flow](https://github.com/facebook/flow)
 

--- a/explore/lib/components.ml
+++ b/explore/lib/components.ml
@@ -108,7 +108,7 @@ let wrap_body ~toc ~title ~description ~body =
 |}] [@@ocamlformat "disable"]
 
 let make_omd_title_date ~title ~date =
-  Omd.of_string ("# " ^ title ^ "\n*Last Updated: " ^ date ^ "*\n\n---\n")
+  Omd.of_string ("# " ^ title ^ "\n*Last Updated: " ^ date ^ "*\n\n")
 
 let make_link_list lst =
   let to_link (path, title) =

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -158,6 +158,11 @@ img {
   background: white;
 }
 
+main h1, main h2 {
+  border-bottom: 1px solid gray;
+  padding-bottom: .67em;
+}
+
 /* === COMPONENTS === */
 
 .ordered-list {


### PR DESCRIPTION
Markdown files used to embed `---` to render an horizontal line.
This uses a CSS rule instead to add a line below `<h1>` and `<h2>` elements in `<main>`.