### PR TITLE
Time tool

### DIFF
--- a/content/platform/dune/index.md
+++ b/content/platform/dune/index.md
@@ -29,9 +29,7 @@ There tend to be three main types of builds that will suffice for most projects:
 
 ### Typical Project Layout
 
-The following file structure is taken from `ocaml-yaml` and has been trimmed to show only the relevant dune-related parts and still be readable. 
-
-[avsm/ocaml-yaml](https://github.com/avsm/ocaml-yaml)
+The following file structure is taken from [`ocaml-yaml`](https://github.com/avsm/ocaml-yaml) and has been trimmed to show only the relevant dune-related parts and still be readable. 
 
 ```
 .

--- a/content/workflows/adding-unit-tests-to-your-project/index.md
+++ b/content/workflows/adding-unit-tests-to-your-project/index.md
@@ -1,16 +1,16 @@
 ---
-authors:
-  - Patrick Ferris
 title: Adding Unit Tests to your Project
-date: 2020-08-05 09:10:42
+date: 2020-09-07 11:52:40 +00:00
+authors:
+- Patrick Ferris
 description: Write tests to check the functionality of your code using Alcotest
-users:
-  - Library Authors
-  - Application Developers
 tools:
-  - Dune
+- Dune
+users:
+- Library Authors
+- Application Developers
 libraries:
-  - Alcotest
+- Alcotest 
 ---
 ## Overview
 
@@ -180,3 +180,4 @@ These tests tend to be written inline with your source OCaml code using `ppx_inl
 ## Real World Examples
 
 [Yojson](https://github.com/ocaml-community/yojson/tree/master/test) is good example of using Alcotest to unit test the different aspects of the library. [Dune-release](https://github.com/ocamllabs/dune-release/tree/master/tests/bin), part of the OCaml Platform, uses Mdx to ensure the CLI tool is properly tested.
+

--- a/explore/bin/main.ml
+++ b/explore/bin/main.ml
@@ -1,6 +1,6 @@
 open Cmdliner
 
-let cmds = [ Build.cmd; Serve.cmd; New.cmd; Lint.cmd ]
+let cmds = [ Build.cmd; Serve.cmd; New.cmd; Lint.cmd; Time.cmd ]
 
 let setup_std_outputs : unit = Fmt_tty.setup_std_outputs ()
 

--- a/explore/bin/time.ml
+++ b/explore/bin/time.ml
@@ -1,0 +1,50 @@
+open Cmdliner
+open Explore
+
+let pp_collection ~yaml ~body ppf =
+  Fmt.string ppf "---\n";
+  Yaml.pp ppf yaml;
+  Fmt.pf ppf "---\n%s" body
+
+let run collection path =
+  match (collection, path) with
+  | "workflow", Some path -> (
+      match Collection.Workflow.v ~path ~content:(Files.read_file path) with
+      | Ok t ->
+          let t = { t with data = { t.data with date = Utils.get_time () } } in
+          let content =
+            pp_collection
+              ~yaml:(Collection.Workflow.workflow_to_yaml t.data)
+              ~body:t.body Format.str_formatter;
+            Format.flush_str_formatter ()
+          in
+          Files.output_file ~path ~content;
+          0
+      | Error _ ->
+          Fmt.(string stdout "Failed to update workflow time");
+          -1)
+  | _ ->
+      Fmt.(
+        string stdout
+          "Failed to update workflow time -- make sure the path is correct");
+      -1
+
+let collection =
+  let docv = "COLLECTION" in
+  let doc =
+    "The type of collection you want to lint e.g. workflow, user etc."
+  in
+  Arg.(value & pos 0 string "workflow" & info ~doc ~docv [])
+
+let path =
+  let docv = "PATH" in
+  let doc = "The path to the collection whose time you would like to update." in
+  Arg.(value & opt (some string) None & info ~doc ~docv [ "path"; "p" ])
+
+let info =
+  let doc = "Print the current time in UTC." in
+  Term.info ~doc "time"
+
+let term = Term.(pure run $ collection $ path)
+
+let cmd = (term, info)

--- a/explore/bin/time.ml
+++ b/explore/bin/time.ml
@@ -23,6 +23,9 @@ let run collection path =
       | Error _ ->
           Fmt.(string stdout "Failed to update workflow time");
           -1)
+  | _, None ->
+      Fmt.(string stdout (Utils.get_time ()));
+      0
   | _ ->
       Fmt.(
         string stdout

--- a/explore/bin/time.mli
+++ b/explore/bin/time.mli
@@ -1,0 +1,1 @@
+val cmd : int Cmdliner.Term.t * Cmdliner.Term.info

--- a/explore/lib/collection.ml
+++ b/explore/lib/collection.ml
@@ -66,7 +66,9 @@ let output ~path ~title yaml =
     Format.flush_str_formatter ()
   in
   Unix.mkdir (path ^ dirname) 0o777;
-  Files.output_file ("---\n" ^ yaml ^ "\n---\n") (path ^ dirname ^ "/index.md")
+  Files.output_file
+    ~content:("---\n" ^ yaml ^ "\n---\n")
+    ~path:(path ^ dirname ^ "/index.md")
 
 module Workflow = struct
   type resource = { title : string; description : string; url : string }

--- a/explore/lib/explore.ml
+++ b/explore/lib/explore.ml
@@ -3,3 +3,4 @@ module Page = Page
 module Build = Build
 module Files = Files
 module Toc = Toc
+module Utils = Utils

--- a/explore/lib/files.ml
+++ b/explore/lib/files.ml
@@ -30,10 +30,10 @@ let read_file filename =
 let title_to_dirname s =
   Core.(String.lowercase s |> String.substr_replace_all ~pattern:" " ~with_:"-")
 
-let output_file str filename =
-  let outc = Out_channel.create filename in
+let output_file ~content ~path =
+  let outc = Out_channel.create path in
   Exn.protect
-    ~f:(fun () -> Out_channel.fprintf outc "%s\n" str)
+    ~f:(fun () -> Out_channel.fprintf outc "%s\n" content)
     ~finally:(fun () -> Out_channel.close outc)
 
 let output_html ~path ~doc =

--- a/explore/lib/files.mli
+++ b/explore/lib/files.mli
@@ -18,5 +18,5 @@ val title_to_dirname : string -> string
 val output_html : path:string -> doc:Tyxml.Html.doc -> unit
 (** [output_html path doc] will print the HTML document [doc] to [path] *)
 
-val output_file : string -> string -> unit
-(** [output_file path content] will dump a [content] to a given [path] *)
+val output_file : content:string -> path:string -> unit
+(** [output_file content path] will dump a [content] to a given [path] *)


### PR DESCRIPTION
All collections are timestamped to reflect when they were last updated. Doing this manually is a bit of pain. `explore time` will print to stdout the current time UTC which can be copied and pasted into the collection. 

Alternatively, a user can specify the collection type and path to have the tool replace the time for them, although it may reorder some of the meta-data the first time this is done. E.g. `explore time workflow --path=content/workflows/adding-unit-tests-to-your-project/index.md` 