### PR TITLE
Outdated CLI tool

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,10 +18,12 @@ jobs:
       run: opam exec -- dune build 
     - name: Install
       run: opam exec -- dune install 
-    - name: Run tests 
+    - name: Run tests 🧪
       run: opam exec -- dune runtest
     - name: Build Site 🔨
       run: opam exec -- explore build 
+    - name: Check for outdated 🕰
+      run: opam exec -- explore outdated -f 
     - name: Move static content 
       run: cp -r ./static/* ./content
     - name: Deploy Preview with Netlify

--- a/explore/bin/main.ml
+++ b/explore/bin/main.ml
@@ -1,6 +1,6 @@
 open Cmdliner
 
-let cmds = [ Build.cmd; Serve.cmd; New.cmd; Lint.cmd; Time.cmd ]
+let cmds = [ Build.cmd; Serve.cmd; New.cmd; Lint.cmd; Time.cmd; Outdated.cmd ]
 
 let setup_std_outputs : unit = Fmt_tty.setup_std_outputs ()
 

--- a/explore/bin/outdated.ml
+++ b/explore/bin/outdated.ml
@@ -1,0 +1,76 @@
+open Cmdliner
+open Explore
+module Jf = Jekyll_format
+
+let time () =
+  Ptime.of_float_s (Unix.gettimeofday ()) |> function
+  | Some t -> t
+  | None -> failwith "Couldn't get current time"
+
+let time_span days =
+  match Ptime.Span.of_d_ps (days, Int64.of_int 0) with
+  | Some t -> t
+  | None -> failwith "Number of days incorrect"
+
+let run fail span =
+  let md_files =
+    List.filter
+      (fun f -> Filename.extension f = ".md")
+      (Files.all_files "content")
+  in
+  let pp_good path =
+    Fmt.(pf stdout "[%a] %s\n" (styled `Green string)) "Up to date" path
+  in
+  let pp_warn path =
+    Fmt.(pf stdout "[%a] %s\n" (styled `Yellow string)) "Update soon" path
+  in
+  let pp_bad path by =
+    Fmt.(pf stdout "[%a] %s by %i days\n" (styled `Red string))
+      "Out of date" path by
+  in
+  let check_file time f =
+    let content = Files.read_file f in
+    let data = Jf.of_string_exn content in
+    let now =
+      match Jf.(find "date" (fields data)) with
+      | Some (`String s) -> Jf.parse_date_exn s
+      | _ ->
+          Fmt.(pf stdout "%a" (styled `Red string) "[Failed to get time]");
+          failwith "error"
+    in
+    let diff = Ptime.diff time now in
+    let comp = diff < time_span span in
+    let days = fst (Ptime.Span.to_d_ps diff) in
+    if comp then if span - days < 5 then pp_warn f else pp_good f
+    else pp_bad f (-(span - days));
+    comp
+  in
+  let status = ref 0 in
+  List.map (check_file (time ())) md_files
+  |> List.iter (fun f -> if fail && f = false then incr status);
+  !status
+
+let span =
+  let docv = "SPAN" in
+  let doc =
+    "Span is the number of days that distinguishes information being out of \
+     date."
+  in
+  Arg.(value & pos 0 int 90 & info ~doc ~docv [])
+
+let fail =
+  let docv = "FAIL" in
+  let doc =
+    "When this flag is set, the outdated command will produce an non-zero \
+     error if some content is found to be outdated"
+  in
+  Arg.(value & flag & info ~doc ~docv [ "f"; "fail" ])
+
+let info =
+  let doc =
+    "Check all files to see which are outdated based on their last update \
+     timestamp."
+  in
+  Term.info ~doc "outdated"
+
+let cmd = (Term.(const run $ fail $ span), info)

--- a/explore/bin/outdated.ml
+++ b/explore/bin/outdated.ml
@@ -12,11 +12,10 @@ let time_span days =
   | Some t -> t
   | None -> failwith "Number of days incorrect"
 
-let run fail span =
+let run fail all span =
+  let dir = if all then "content" else "content/workflows" in
   let md_files =
-    List.filter
-      (fun f -> Filename.extension f = ".md")
-      (Files.all_files "content")
+    List.filter (fun f -> Filename.extension f = ".md") (Files.all_files dir)
   in
   let pp_good path =
     Fmt.(pf stdout "[%a] %s\n" (styled `Green string)) "Up to date" path
@@ -66,6 +65,14 @@ let fail =
   in
   Arg.(value & flag & info ~doc ~docv [ "f"; "fail" ])
 
+let all =
+  let docv = "ALL" in
+  let doc =
+    "Without this flag set, outdated will only check the workflows directory \
+     seeing as these are the most important to keep up to date"
+  in
+  Arg.(value & flag & info ~doc ~docv [ "a"; "all" ])
+
 let info =
   let doc =
     "Check all files to see which are outdated based on their last update \
@@ -73,4 +80,4 @@ let info =
   in
   Term.info ~doc "outdated"
 
-let cmd = (Term.(const run $ fail $ span), info)
+let cmd = (Term.(const run $ fail $ all $ span), info)

--- a/explore/bin/outdated.mli
+++ b/explore/bin/outdated.mli
@@ -1,0 +1,1 @@
+val cmd : int Cmdliner.Term.t * Cmdliner.Term.info


### PR DESCRIPTION
The outdated CLI tool checks all markdown files in `content`, extracts their date field and compares it with a specified number of days (default `90`) to see if they are up to date or not.

It has two parameters the span (i.e. number of days that are allowed to pass before something becomes outdated) and a flag `-f/--fail` to tell the tool whether a failing date should return an error or not (used to either just check or for the, as in the Github Action, to fail). 