### PR TITLE
add source code button

### DIFF
--- a/explore/lib/collection.ml
+++ b/explore/lib/collection.ml
@@ -229,7 +229,14 @@ module Workflow = struct
     Components.wrap_body
       ~toc:(Some [ toc ])
       ~title:t.data.title ~description:t.data.description
-      ~body:([ Html.Unsafe.data (Omd.to_html (Toc.transform omd)) ] @ resources)
+      ~body:
+        ([
+           Html.Unsafe.data
+             (Omd.to_html
+                (Toc.transform omd
+                |> Utils.code_to_html (Files.title_to_dirname t.data.title)));
+         ]
+        @ resources)
 end
 
 module type Collection = sig

--- a/explore/lib/utils.ml
+++ b/explore/lib/utils.ml
@@ -1,3 +1,5 @@
+open Tyxml
+
 let get_time () =
   Ptime.of_float_s (Unix.gettimeofday ()) |> function
   | Some t ->
@@ -9,3 +11,47 @@ let elt_to_string elt =
   let open Tyxml in
   Format.(fprintf str_formatter "%a\n" (Html.pp_elt ()) elt);
   Format.flush_str_formatter ()
+
+let extract_file s =
+  let rec extract = function
+    | "file" :: file :: _ -> Some file
+    | _ :: xs -> extract xs
+    | [] -> None
+  in
+  Core.String.split_on_chars ~on:[ '='; ','; ' ' ] s |> extract
+
+let code_to_html workflow (bs : Omd.block list) =
+  let rec loop (acc : Omd.block list) (bs : Omd.block list) =
+    match bs with
+    (* MDX requires a comment before the code block *)
+    | { bl_desc = Omd.Html_block html; _ }
+      :: ({ bl_desc = Omd.Code_block _; _ } as c) :: bs ->
+        let file =
+          match extract_file html with
+          | Some f -> f
+          | None -> failwith "Could not parse MDX comment"
+        in
+        let uri =
+          "https://github.com/ocaml-explore/explore/tree/trunk/content/workflows/"
+          ^ workflow
+          ^ "/"
+          ^ file
+        in
+        let button =
+          [%html
+            "<div><p class='toolbar'><a href=" uri ">Source Code</a></p></div>"]
+        in
+
+        let code =
+          [%html
+            "<div>"
+              [ button; Tyxml.Html.Unsafe.data (Omd.to_html [ c ]) ]
+              "</div>"]
+          |> Tyxml.Html.pp_elt () Format.str_formatter;
+          Format.flush_str_formatter ()
+        in
+        loop ({ bl_desc = Omd.Html_block code; bl_attributes = [] } :: acc) bs
+    | b :: bs -> loop (b :: acc) bs
+    | [] -> List.rev acc
+  in
+  loop [] bs

--- a/explore/lib/utils.mli
+++ b/explore/lib/utils.mli
@@ -2,3 +2,8 @@ val get_time : unit -> string
 
 val elt_to_string : 'a Tyxml_html.elt -> string
 (** [elt_to_string elt] takes a Tyxml HTML element and prints it to a string *)
+
+val code_to_html : string -> Omd.block list -> Omd.block list
+(** [code_to_html filename bs] Converts code blocks to HTML blocks for a given
+    set of Omd blocks -- it adds some additional features like source code links
+    hence it is a different phase *)

--- a/explore/tests/test.ml
+++ b/explore/tests/test.ml
@@ -4,4 +4,5 @@ let () =
       ("Collections", Test_collection.tests);
       ("Files", Test_files.tests);
       ("Toc", Test_toc.tests);
+      ("Utils", Test_utils.tests);
     ]

--- a/explore/tests/test_utils.ml
+++ b/explore/tests/test_utils.ml
@@ -1,0 +1,13 @@
+open Explore
+
+let test_code_to_html () =
+  let md = "<!-- $MDX file=examples/lib -->\n```ocaml\nlet () = ()\n```" in
+  let test = Utils.code_to_html "my-file" (Omd.of_string md) in
+  let correct : Omd.block list = [{ bl_desc = Omd.Html_block "<div><div><p class=\"toolbar\"><a href=\"https://github.com/ocaml-explore/explore/tree/trunk/content/workflows/my-file/examples/lib\">Source Code</a></p></div><pre><code class=\"language-ocaml\">let () = ()
+</code></pre>
+</div>"; bl_attributes = []}] [@@ocamlformat "disable"] in
+  let pp ppf b = Format.pp_print_string ppf (Omd.to_sexp b) in
+  let omd = Alcotest.testable pp Stdlib.( = ) in
+  Alcotest.check omd "same omd" correct test
+
+let tests = [ ("test_code_to_html", `Quick, test_code_to_html) ]

--- a/explore/tests/test_utils.mli
+++ b/explore/tests/test_utils.mli
@@ -1,0 +1,1 @@
+val tests : unit Alcotest.test_case list

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -206,6 +206,10 @@ main h1, main h2 {
   background-color: #C68677;
 }
 
+.toolbar {
+  text-align: right;
+}
+
 /* === TOC === */
 .toc {
   list-style-type: none;


### PR DESCRIPTION
This PR adds a button to jump straight to the source code in `trunk` for the MDX code blocks which use it (fixes #42)