### PR TITLE
show help when no args given

### DIFF
--- a/explore/bin/main.ml
+++ b/explore/bin/main.ml
@@ -6,7 +6,8 @@ let setup_std_outputs : unit = Fmt_tty.setup_std_outputs ()
 
 let doc = "Explore OCaml CLI tool"
 
-let main = (fst Build.cmd, Term.info "explore" ~doc)
+let main =
+  (Term.ret @@ Term.pure (`Help (`Pager, None)), Term.info "explore" ~doc)
 
 let main () = Term.(exit_status @@ eval_choice main cmds)
 


### PR DESCRIPTION
As suggested by @gs0510 (thanks!), this PR makes the default behaviour of `explore` be to show the man-page :)) 

Fixes #45 