### PR TITLE
update ppx yaml and fix user-workflow finding

### DIFF
--- a/explore.opam
+++ b/explore.opam
@@ -49,5 +49,5 @@ pin-depends: [
   ["omd.dev" "git+https://github.com/ocaml/omd"]
   ["jekyll-format.dev" "git+https://github.com/patricoferris/jekyll-format#fields-to-yaml"]
   ["bechamel.dev" "git+https://github.com/dinosaure/bechamel#f1b3db0115af3854422697134a1555e3c07a19f5"]
-  ["ppx_deriving_yaml.dev" "git+https://github.com/patricoferris/ppx_deriving_yaml#5b333ff646daa30d8a9fedb2604946d721fe1a07"]
+  ["ppx_deriving_yaml.dev" "git+https://github.com/patricoferris/ppx_deriving_yaml#bde2bf2dde8f8115c4705613b3889d9941b74f18"]
 ]

--- a/explore.opam.template
+++ b/explore.opam.template
@@ -2,5 +2,5 @@ pin-depends: [
   ["omd.dev" "git+https://github.com/ocaml/omd"]
   ["jekyll-format.dev" "git+https://github.com/patricoferris/jekyll-format#fields-to-yaml"]
   ["bechamel.dev" "git+https://github.com/dinosaure/bechamel#f1b3db0115af3854422697134a1555e3c07a19f5"]
-  ["ppx_deriving_yaml.dev" "git+https://github.com/patricoferris/ppx_deriving_yaml#5b333ff646daa30d8a9fedb2604946d721fe1a07"]
+  ["ppx_deriving_yaml.dev" "git+https://github.com/patricoferris/ppx_deriving_yaml#bde2bf2dde8f8115c4705613b3889d9941b74f18"]
 ]

--- a/explore/lib/collection.ml
+++ b/explore/lib/collection.ml
@@ -391,7 +391,11 @@ module User = struct
   let get_workflows t (workflows : Workflow.t list) =
     List.map
       (fun tt ->
-        try List.find (fun (w : Workflow.t) -> tt = w.data.title) workflows
+        try
+          List.find
+            (fun (w : Workflow.t) ->
+              String.lowercase_ascii tt = String.lowercase_ascii w.data.title)
+            workflows
         with Not_found ->
           failwith
             ("[Workflow Error] Could not find `"


### PR DESCRIPTION
This PR makes the linking between workflow titles in `Users` and `Workflows` less brittle by converting all to lowercase -- it also updates the version of `ppx_deriving_yaml` to the latest (unreleased) version.

---

Fixes #49 